### PR TITLE
Build and push burnham Docker image on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ workflows:
             parameters:
               tox_env: ["flake8", "mypy", "py37"]
       - gcp-gcr/build-and-push-image:
+          name: Build and push image
           context: data-eng-airflow-gcr
           path: application
           dockerfile: application/Dockerfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,4 +44,4 @@ workflows:
             - run_checks
           filters:
             branches:
-              only: set-up-ci-for-docker-image
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           context: data-eng-airflow-gcr
           path: application
+          dockerfile: application/Dockerfile
           image: burnham
           requires:
             - run_checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,4 +42,4 @@ workflows:
             - run_checks
           filters:
             branches:
-              only: main
+              only: set-up-ci-for-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+# See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
+orbs:
+  gcp-gcr: circleci/gcp-gcr@0.6.1
+
 jobs:
   run_checks:
     docker:
@@ -30,3 +34,16 @@ workflows:
           matrix:
             parameters:
               tox_env: ["flake8", "mypy", "py37"]
+      - gcp-gcr/build-and-push-image:
+          # This step relies on several environment variables provided to the
+          # build job via Circle CI configuration:
+          #   GCLOUD_SERVICE_KEY
+          #   GOOGLE_PROJECT_ID
+          #   GOOGLE_COMPUTE_ZONE
+          path: application
+          image: burnham
+          requires:
+            - run_checks
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
             parameters:
               tox_env: ["flake8", "mypy", "py37"]
       - gcp-gcr/build-and-push-image:
-        context: data-eng-airflow-gcr
+          context: data-eng-airflow-gcr
           path: application
           image: burnham
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,7 @@ workflows:
             parameters:
               tox_env: ["flake8", "mypy", "py37"]
       - gcp-gcr/build-and-push-image:
-          # This step relies on several environment variables provided to the
-          # build job via Circle CI configuration:
-          #   GCLOUD_SERVICE_KEY
-          #   GOOGLE_PROJECT_ID
-          #   GOOGLE_COMPUTE_ZONE
+        context: data-eng-airflow-gcr
           path: application
           image: burnham
           requires:


### PR DESCRIPTION
Hi @jklukas @jasonthomas! 👋 

This pull-request updates the Circle CI config to build and push a Docker image to the Data Platform for our Glean end-to-end tests. I created a draft pull-request for a new Airflow DAG that relies on this Docker image at https://github.com/mozilla/telemetry-airflow/pull/1039.

I decided to use the same Circle CI orb as the forecasting project:
https://github.com/mozilla/forecasting/blob/master/.circleci/config.yml

Can you please help me set up the missing GCP info for the workflow? 📦 

Resolve #26 