### PR TITLE
Pin the Glean SDK to version 31.0.0 📦

### DIFF
--- a/application/setup.py
+++ b/application/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     package_data={"burnham": ["config/*.yaml"]},
     zip_safe=False,
     python_requires=">=3.7",
-    install_requires=["click>=7.0", "glean-sdk>=31.0.0", "wrapt", "typing_extensions"],
+    install_requires=["click>=7.0", "glean-sdk==31.0.0", "wrapt", "typing_extensions"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
I ran into a schema validation error with `glean-sdk-31.1.2` (bug 1638877) when submitting to the data platform. The pinned version is the most recent version that doesn't have the database issue (bug 1646173).

cc @wlach 