### PR TITLE
Create QueryJobConfig for burnham_test_run

### DIFF
--- a/bigquery/tests/test_burnham.py
+++ b/bigquery/tests/test_burnham.py
@@ -4,13 +4,16 @@
 
 from typing import Any, List
 
-from google.cloud.bigquery import Client
+from google.cloud import bigquery
 
 
-def test_burnham(bq_client: Client, query: str, want: List[Any]):
+def test_burnham(
+    client: bigquery.Client,
+    query_job_config: bigquery.QueryJobConfig,
+    query: str,
+    want: List[Any],
+):
     """Test that the Glean telemetry in BigQuery matches what we expect."""
-
-    job = bq_client.query(query)
-    got = [row for row in job.result()]
-
+    query_job = client.query(query, job_config=query_job_config)
+    got = [row for row in query_job.result()]
     assert got == want


### PR DESCRIPTION
We encode the SQL query in telemetry-airflow before the test run UUID template is rendered. To avoid this from happening, this pull-request updates the test framework to create a `QueryJobConfig` for a new `@burnham_test_run` with the value for the `--run-id` CLI option.

Relevant documentation https://cloud.google.com/bigquery/docs/parameterized-queries

Resolve #47 