### PR TITLE
Create dict from bigquery.Row in test

### DIFF
--- a/bigquery/tests/test_burnham.py
+++ b/bigquery/tests/test_burnham.py
@@ -15,5 +15,5 @@ def test_burnham(
 ):
     """Test that the Glean telemetry in BigQuery matches what we expect."""
     query_job = client.query(query, job_config=query_job_config)
-    got = [row for row in query_job.result()]
+    got = [dict(row.items()) for row in query_job.result()]
     assert got == want


### PR DESCRIPTION
According to the bigquery client documentation `row.items()` returns a `Iterable[Tuple[str, object]]`. We can use that for creating a new `Dict` to match the type from telemetry-airflow.

https://github.com/googleapis/python-bigquery/blob/a2d5ce9e97992318d7dc85c51c053cab74e25a11/google/cloud/bigquery/table.py#L1211