### PR TITLE
Move dependabot file to correct folder.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "application/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Missed this in the docs. I apoligise. ```Check the dependabot.yml configuration file in to the .github directory of the repository.```