### PR TITLE
Sleep briefly before exiting after all missions finished

### DIFF
--- a/application/src/burnham/cli.py
+++ b/application/src/burnham/cli.py
@@ -4,6 +4,7 @@
 
 import logging
 import sys
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Tuple
@@ -16,6 +17,8 @@ from burnham import __title__, __version__, metrics, pings
 from burnham.exceptions import BurnhamError
 from burnham.missions import Mission, complete_mission, missions_by_identifier
 from burnham.space_travel import Discovery, SporeDrive, WarpDrive
+
+logger = logging.getLogger(__name__)
 
 
 class MissionParamType(click.ParamType):
@@ -147,6 +150,9 @@ def burnham(
             if mission.identifier == "MISSION I: ENABLE GLEAN UPLOAD":
                 metrics.test.run.set(test_run)
                 metrics.test.name.set(test_name)
+
+            logger.info("All missions completed. Waiting for telemetry to be sent.")
+            time.sleep(5)
 
     except BurnhamError as err:
         click.echo(f"Error: {err}", err=True)

--- a/application/src/burnham/cli.py
+++ b/application/src/burnham/cli.py
@@ -151,8 +151,10 @@ def burnham(
                 metrics.test.run.set(test_run)
                 metrics.test.name.set(test_name)
 
-            logger.info("All missions completed. Waiting for telemetry to be sent.")
-            time.sleep(5)
+        secs = 5
+        logger.info("All missions completed.")
+        logger.info(f" Waiting {secs}s for telemetry to be sent.")
+        time.sleep(secs)
 
     except BurnhamError as err:
         click.echo(f"Error: {err}", err=True)


### PR DESCRIPTION
Glean sends pings asynchronously from another process.
When this runs within a docker container the container will be destroyed
as soon as burnham exits, leaving no time for the uploader to send
pings.
By briefly waiting we let the process handle sending some pings and only
then exit.

Note: the wait time is completely arbitrary. Under normal circumstances
the upload should be finished well within a second, so sleeping a bit
longer is just a precaution.
This will stil result in pings not being sent if they are stuck for
other reasons.