### PR TITLE
Bump gcp-gcr orb version in CircleCI config 📦

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.6.1
+  gcp-gcr: circleci/gcp-gcr@0.13.0
 
 jobs:
   run_checks:


### PR DESCRIPTION
Let's see if that solves the `google-cloud-sdk` installation issues in the CircleCI docker build and push jobs.