### PR TITLE
Fix gcp-gcr parameters for new orb version 📦

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham 📦
           context: data-eng-airflow-gcr
-          docker-context: application
-          dockerfile: application/Dockerfile
+          path: application
           image: burnham
           requires:
             - run_checks
@@ -48,8 +47,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham-bigquery 📦
           context: data-eng-airflow-gcr
-          docker-context: bigquery
-          dockerfile: bigquery/Dockerfile
+          path: bigquery
           image: burnham-bigquery
           requires:
             - run_checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham 📦
           context: data-eng-airflow-gcr
-          path: application
+          docker-context: application
           image: burnham
           requires:
             - run_checks
@@ -47,7 +47,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham-bigquery 📦
           context: data-eng-airflow-gcr
-          path: bigquery
+          docker-context: bigquery
           image: burnham-bigquery
           requires:
             - run_checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham 📦
           context: data-eng-airflow-gcr
-          path: application
+          docker-context: application
           dockerfile: application/Dockerfile
           image: burnham
           requires:
@@ -48,7 +48,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham-bigquery 📦
           context: data-eng-airflow-gcr
-          path: bigquery
+          docker-context: bigquery
           dockerfile: bigquery/Dockerfile
           image: burnham-bigquery
           requires:


### PR DESCRIPTION
Follow-up pull request for #228.

Looks like the orb parameters have changed. I processed the CI config locally and the generated Docker build commands look OK to me now.

https://circleci.com/developer/orbs/orb/circleci/gcp-gcr#jobs-build-and-push-image