### PR TITLE
Specify path parameter in Docker CircleCI orb 📦

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham 📦
           context: data-eng-airflow-gcr
+          path: application
           docker-context: application
           image: burnham
           requires:
@@ -47,6 +48,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build and push burnham-bigquery 📦
           context: data-eng-airflow-gcr
+          path: bigquery
           docker-context: bigquery
           image: burnham-bigquery
           requires:


### PR DESCRIPTION
Looks we we still need `path`. Follow-up for #229 