### PR TITLE
Bug 1734011 - Add basic set of tags to burnham

### DIFF
--- a/application/src/burnham/config/metrics.yaml
+++ b/application/src/burnham/config/metrics.yaml
@@ -3,13 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ---
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 test:
   run:
     type: uuid
     description: >
       ID of the current test run.
+    metadata:
+      tags:
+        - automation
     lifetime: application
     send_in_pings:
       - discovery
@@ -28,6 +31,9 @@ test:
     type: string
     description: >
       Name of the current test.
+    metadata:
+      tags:
+        - automation
     lifetime: application
     send_in_pings:
       - discovery
@@ -47,6 +53,9 @@ technology:
     type: labeled_counter
     description: >
       Counts the number of times a space-travel technology is used.
+    metadata:
+      tags:
+        - science
     labels:
       - warp_drive
       - spore_drive
@@ -65,6 +74,9 @@ mission:
     type: string
     description: >
       The identifier of the current mission.
+    metadata:
+      tags:
+        - science
     lifetime: application
     send_in_pings:
       - discovery
@@ -80,6 +92,9 @@ mission:
     type: string
     description: >
       The status of the current mission.
+    metadata:
+      tags:
+        - science
     lifetime: application
     send_in_pings:
       - discovery

--- a/application/src/burnham/config/pings.yaml
+++ b/application/src/burnham/config/pings.yaml
@@ -3,11 +3,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ---
-$schema: moz://mozilla.org/schemas/glean/pings/1-0-0
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 
 discovery:
   description: >
     Custom ping sent by the burnham CLI app.
+  metadata:
+    tags:
+      - science
+      - automation
   include_client_id: true
   bugs:
     - https://github.com/mozilla/burnham/issues/5
@@ -19,6 +23,10 @@ discovery:
 space-ship-ready:
   description: >
     Custom ping for testing kebab-case ping names.
+  metadata:
+    tags:
+      - science
+      - automation
   include_client_id: true
   bugs:
     - https://github.com/mozilla/burnham/issues/8
@@ -30,6 +38,10 @@ space-ship-ready:
 starbase46:
   description: >
     Custom ping for testing ping names that contain numbers.
+  metadata:
+    tags:
+      - science
+      - automation
   include_client_id: true
   bugs:
     - https://github.com/mozilla/burnham/issues/8

--- a/application/src/burnham/config/tags.yaml
+++ b/application/src/burnham/config/tags.yaml
@@ -1,0 +1,10 @@
+---
+$schema: moz://mozilla.org/schemas/glean/tags/1-0-0
+
+automation:
+  description: |
+    *Automation* metrics 🏭
+
+science:
+  description: |
+    *Science* metrics 🚀

--- a/application/tox.ini
+++ b/application/tox.ini
@@ -58,4 +58,4 @@ commands_pre =
     # Install the pinned burnham requirements
     pip-sync {toxinidir}/requirements.txt
 commands =
-    glean_parser glinter src/burnham/config/metrics.yaml src/burnham/config/pings.yaml
+    glean_parser glinter --require-tags src/burnham/config/metrics.yaml src/burnham/config/pings.yaml src/burnham/config/tags.yaml


### PR DESCRIPTION
This is to test the new Glean tagging feature. Not yet ready to be
merged.
