### PR TITLE
Update Dependabot schedule to Fridays 🤖

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "application/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     labels:
       - "Dependabot"
       - "dependencies"


### PR DESCRIPTION
As discussed on Matrix, we need to reduce the frequency and number of Dependabot pull requests while we're building custom tooling to automatically upgrade Glean dependencies in burnham.
